### PR TITLE
Docker machine env dump is now set to bash

### DIFF
--- a/bin/docker-machine-init
+++ b/bin/docker-machine-init
@@ -129,7 +129,7 @@ echo "===> Starting Gobetween..."
 echo "export DOCKER_CLI_BIN_PATH=\"$(brew --prefix docker-cli)/bin/docker\"" > /tmp/docker-virtualbox.env
 echo "export DOCKER_COMPOSE_BIN_PATH=\"$(brew --prefix docker-compose)/bin/docker-compose\"" >> /tmp/docker-virtualbox.env
 echo "export DOCKER_MACHINE_IP=\"$(${DOCKER_MACHINE_BIN} ip ${DOCKER_MACHINE_MACHINE_NAME})\"" >> /tmp/docker-virtualbox.env
-${DOCKER_MACHINE_BIN} env ${DOCKER_MACHINE_MACHINE_NAME} >> /tmp/docker-virtualbox.env
+${DOCKER_MACHINE_BIN} env ${DOCKER_MACHINE_MACHINE_NAME} --shell bash >> /tmp/docker-virtualbox.env
 ${TERMINAL_NOTIFIER_BIN} -title "Docker Virtualbox" -message "Virtual machine '${DOCKER_MACHINE_MACHINE_NAME}' ready for work"
 
 


### PR DESCRIPTION
👋 Hey there, thanks for this script, it saved me a ton of trouble on my Ryzentosh <3

I've installed fish as a shell, and the script didn't work. After some digging I've noticed that you correctly set the shell for the script to be `#!/usr/bin/env bash` but because my shell is not that by default (nor a compatible one), what happens is [described here](https://docs.docker.com/machine/reference/env/)

> If you are using fish and the SHELL environment variable is correctly set to the path where fish is located, docker-machine env name prints out the values in the format which fish expects

I've added a flag to docker-machine env to force it to dump the environment variables using bash syntax, as we're running this script in bash anyway.
