### PR TITLE
Allows docker-machine to switch to other machines

### DIFF
--- a/bin/docker
+++ b/bin/docker
@@ -15,7 +15,7 @@ if [[ -f /tmp/docker-virtualbox.starting ]]; then
     done
 fi
 
-[[ -f /tmp/docker-virtualbox.env ]] || {
+[[ -f /tmp/docker-virtualbox.env && -f /tmp/docker-virtualbox-machine.env ]] || {
     echo -e "\033[91m"
     echo -e "\033[91mLooks like docker-virtualbox doesn't work"
     echo -e ""
@@ -27,5 +27,9 @@ fi
 }
 
 source /tmp/docker-virtualbox.env
+
+[[ -z "${DOCKER_HOST}" ]] && { 
+    source /tmp/docker-virtualbox-machine.env
+}
 
 exec ${DOCKER_CLI_BIN_PATH} "$@"

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -15,17 +15,21 @@ if [[ -f /tmp/docker-virtualbox.starting ]]; then
     done
 fi
 
-[[ -f /tmp/docker-virtualbox.env ]] || {
+[[ -f /tmp/docker-virtualbox.env && -f /tmp/docker-virtualbox-machine.env ]] || {
     echo -e "\033[91m"
     echo -e "\033[91mLooks like docker-virtualbox doesn't work"
     echo -e ""
     echo -e "\033[0mYou have to start it by following command:"
     echo -e ""
-    echo -e "\033[96mbrew services start docker-virtualbox"
+    echo -e "\033[96mbrew services start docker-virtualbox "
     echo -e "\033[0m"
     exit 1
 }
 
 source /tmp/docker-virtualbox.env
+
+[[ -z "${DOCKER_HOST}" ]] && { 
+    source /tmp/docker-virtualbox-machine.env
+}
 
 exec ${DOCKER_COMPOSE_BIN_PATH} "$@"

--- a/bin/docker-machine-init
+++ b/bin/docker-machine-init
@@ -35,6 +35,7 @@ DOCKER_MACHINE_MACHINE_NAME=${DOCKER_MACHINE_NAME-docker}
 function stop()
 {
     [[ -f /tmp/docker-virtualbox.env ]] && rm /tmp/docker-virtualbox.env
+    [[ -f /tmp/docker-virtualbox-machine.env ]] && rm /tmp/docker-virtualbox-machine.env
     echo "===> Stopping docker machine: ${DOCKER_MACHINE_MACHINE_NAME}"
     ${TERMINAL_NOTIFIER_BIN} -title "Docker Virtualbox" -message "Stopping virtual machine: '${DOCKER_MACHINE_MACHINE_NAME}'"
     ${DOCKER_MACHINE_BIN} stop ${DOCKER_MACHINE_MACHINE_NAME}
@@ -130,11 +131,12 @@ echo "===> Starting Gobetween..."
 echo "export DOCKER_CLI_BIN_PATH=\"$(brew --prefix docker-cli)/bin/docker\"" > /tmp/docker-virtualbox.env
 echo "export DOCKER_COMPOSE_BIN_PATH=\"$(brew --prefix docker-compose)/bin/docker-compose\"" >> /tmp/docker-virtualbox.env
 echo "export DOCKER_MACHINE_IP=\"$(${DOCKER_MACHINE_BIN} ip ${DOCKER_MACHINE_MACHINE_NAME})\"" >> /tmp/docker-virtualbox.env
-${DOCKER_MACHINE_BIN} env ${DOCKER_MACHINE_MACHINE_NAME} --shell bash >> /tmp/docker-virtualbox.env
+${DOCKER_MACHINE_BIN} env ${DOCKER_MACHINE_MACHINE_NAME} --shell bash >> /tmp/docker-virtualbox-machine.env
 ${TERMINAL_NOTIFIER_BIN} -title "Docker Virtualbox" -message "Virtual machine '${DOCKER_MACHINE_MACHINE_NAME}' ready for work"
 
 
 source /tmp/docker-virtualbox.env
+source /tmp/docker-virtualbox-machine.env
 
 echo ""
 echo "===> Listen for events..."


### PR DESCRIPTION
Hey, Thanks for this script, it is very helpful for me!

I've added some remote machines through docker-machine and tried to use `eval $(docker-machine env xxx)` to switch machines but it didn't seem to work. After some digging, I've noticed that the script uses `source /tmp/docker-virtualbox.env` to export the default machine env every time the docker command is called.

I‘ve added the judgment of the environment to identify whether the machine is activated so that the script can source other machines env and docker-machine can active other machines normally.

