### PR TITLE
Add enable custom environment path for brew

### DIFF
--- a/bin/docker-machine-init
+++ b/bin/docker-machine-init
@@ -16,7 +16,9 @@ LOGDIR="/tmp";
 
 START_TIME=$(date +%s)
 
-if [[ "Darwin" == "$(uname)" ]]; then
+if [[ -n "${BREW_BIN}" ]]; then
+    BREW_BIN=$BREW_BIN
+elif [[ "Darwin" == "$(uname)" ]]; then
     BREW_BIN=/usr/local/bin
 else
     BREW_BIN=/home/linuxbrew/.linuxbrew/bin


### PR DESCRIPTION
This is a small fix that allows a custom path to be declared for `brew`.

It is common to have `brew` in a non-default location when the system is multi-user, as it keeps packages seperate from other users on the machine.

The code sample checks for an environment variable called `BREW_BIN` and uses that, falling back to the existing logic if it does not exist.